### PR TITLE
Bump last update date

### DIFF
--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base   imagecarousel
 author lisps, peterfromearth
 email  coder@peterfromearth.de
-date   2019-04-17
+date   2020-02-29
 name   imagecarousel plugin
 desc   carousel for images with imagebox
 url    https://dokuwiki.org/plugin:imagecarousel


### PR DESCRIPTION
The date did not match the last updated date item on https://www.dokuwiki.org/plugin:imagecarousel (which is 2020-02-29). This upsets Dokuwiki Extension Manager and it always shows the plugin as outdated.